### PR TITLE
Fix ParamsTypeName template context bug and normalize variable access

### DIFF
--- a/experimental/internal/codegen/templates/files/client/interface.go.tmpl
+++ b/experimental/internal/codegen/templates/files/client/interface.go.tmpl
@@ -5,12 +5,13 @@ type ClientInterface interface {
 {{- range . }}
 {{- $opid := .GoOperationID }}
 {{- $hasParams := .HasParams }}
+{{- $paramsTypeName := .ParamsTypeName }}
 {{- $pathParams := .PathParams }}
 	// {{ $opid }}{{ if .HasBody }}WithBody{{ end }} makes a {{ .Method }} request to {{ .Path }}
-	{{ $opid }}{{ if .HasBody }}WithBody{{ end }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ .ParamsTypeName }}{{ end }}{{ if .HasBody }}, contentType string, body io.Reader{{ end }}, reqEditors ...RequestEditorFn) (*http.Response, error)
+	{{ $opid }}{{ if .HasBody }}WithBody{{ end }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, contentType string, body io.Reader{{ end }}, reqEditors ...RequestEditorFn) (*http.Response, error)
 {{- range .Bodies }}
 {{- if .IsJSON }}
-	{{ $opid }}{{ .FuncSuffix }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $.ParamsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error)
+	{{ $opid }}{{ .FuncSuffix }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error)
 {{- end }}
 {{- end }}
 {{- end }}

--- a/experimental/internal/codegen/templates/files/initiator/interface.go.tmpl
+++ b/experimental/internal/codegen/templates/files/initiator/interface.go.tmpl
@@ -6,11 +6,13 @@ type {{ .Prefix }}InitiatorInterface interface {
 {{- range .Operations }}
 {{- $opid := .GoOperationID }}
 {{- $hasParams := .HasParams }}
-	// {{ $opid }}{{ if .HasBody }}WithBody{{ end }} sends a {{ .Method }} {{ $.PrefixLower }} request
-	{{ $opid }}{{ if .HasBody }}WithBody{{ end }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ .ParamsTypeName }}{{ end }}{{ if .HasBody }}, contentType string, body io.Reader{{ end }}, reqEditors ...RequestEditorFn) (*http.Response, error)
+{{- $paramsTypeName := .ParamsTypeName }}
+{{- $prefixLower := $.PrefixLower }}
+	// {{ $opid }}{{ if .HasBody }}WithBody{{ end }} sends a {{ .Method }} {{ $prefixLower }} request
+	{{ $opid }}{{ if .HasBody }}WithBody{{ end }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, contentType string, body io.Reader{{ end }}, reqEditors ...RequestEditorFn) (*http.Response, error)
 {{- range .Bodies }}
 {{- if .IsJSON }}
-	{{ $opid }}{{ .FuncSuffix }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $.ParamsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error)
+	{{ $opid }}{{ .FuncSuffix }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error)
 {{- end }}
 {{- end }}
 {{- end }}

--- a/experimental/internal/codegen/templates/files/initiator/methods.go.tmpl
+++ b/experimental/internal/codegen/templates/files/initiator/methods.go.tmpl
@@ -7,11 +7,12 @@
 {{- $hasParams := .HasParams }}
 {{- $paramsTypeName := .ParamsTypeName }}
 {{- $prefix := $.Prefix }}
+{{- $prefixLower := $.PrefixLower }}
 
-// {{ $opid }}{{ if .HasBody }}WithBody{{ end }} sends a {{ .Method }} {{ $.PrefixLower }} request
+// {{ $opid }}{{ if .HasBody }}WithBody{{ end }} sends a {{ .Method }} {{ $prefixLower }} request
 {{ if .Summary }}// {{ .Summary }}{{ end }}
 func (p *{{ $prefix }}Initiator) {{ $opid }}{{ if .HasBody }}WithBody{{ end }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, contentType string, body io.Reader{{ end }}, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := New{{ $opid }}{{ $.Prefix }}Request{{ if .HasBody }}WithBody{{ end }}(targetURL{{ if $hasParams }}, params{{ end }}{{ if .HasBody }}, contentType, body{{ end }})
+	req, err := New{{ $opid }}{{ $prefix }}Request{{ if .HasBody }}WithBody{{ end }}(targetURL{{ if $hasParams }}, params{{ end }}{{ if .HasBody }}, contentType, body{{ end }})
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +25,7 @@ func (p *{{ $prefix }}Initiator) {{ $opid }}{{ if .HasBody }}WithBody{{ end }}(c
 {{- range .Bodies }}
 {{- if .IsJSON }}
 
-// {{ $opid }}{{ .FuncSuffix }} sends a {{ $op.Method }} {{ $.PrefixLower }} request with JSON body
+// {{ $opid }}{{ .FuncSuffix }} sends a {{ $op.Method }} {{ $prefixLower }} request with JSON body
 func (p *{{ $prefix }}Initiator) {{ $opid }}{{ .FuncSuffix }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := New{{ $opid }}{{ $prefix }}Request{{ .FuncSuffix }}(targetURL{{ if $hasParams }}, params{{ end }}, body)
 	if err != nil {

--- a/experimental/internal/codegen/templates/files/initiator/request_builders.go.tmpl
+++ b/experimental/internal/codegen/templates/files/initiator/request_builders.go.tmpl
@@ -10,12 +10,13 @@
 {{- $headerParams := .HeaderParams }}
 {{- $cookieParams := .CookieParams }}
 {{- $prefix := $.Prefix }}
+{{- $prefixLower := $.PrefixLower }}
 
 {{- /* Generate typed body request builders for JSON bodies */ -}}
 {{- range .Bodies }}
 {{- if .IsJSON }}
 
-// New{{ $opid }}{{ $prefix }}Request{{ .FuncSuffix }} creates a {{ $op.Method }} request for the {{ $.PrefixLower }} with {{ .ContentType }} body
+// New{{ $opid }}{{ $prefix }}Request{{ .FuncSuffix }} creates a {{ $op.Method }} request for the {{ $prefixLower }} with {{ .ContentType }} body
 func New{{ $opid }}{{ $prefix }}Request{{ .FuncSuffix }}(targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
@@ -28,7 +29,7 @@ func New{{ $opid }}{{ $prefix }}Request{{ .FuncSuffix }}(targetURL string{{ if $
 {{- end }}
 {{- end }}
 
-// New{{ $opid }}{{ $prefix }}Request{{ if .HasBody }}WithBody{{ end }} creates a {{ .Method }} request for the {{ $.PrefixLower }}{{ if .HasBody }} with any body{{ end }}
+// New{{ $opid }}{{ $prefix }}Request{{ if .HasBody }}WithBody{{ end }} creates a {{ .Method }} request for the {{ $prefixLower }}{{ if .HasBody }} with any body{{ end }}
 func New{{ $opid }}{{ $prefix }}Request{{ if .HasBody }}WithBody{{ end }}(targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, contentType string, body io.Reader{{ end }}) (*http.Request, error) {
 	var err error
 

--- a/experimental/internal/codegen/templates/files/initiator/simple.go.tmpl
+++ b/experimental/internal/codegen/templates/files/initiator/simple.go.tmpl
@@ -34,6 +34,8 @@ func NewSimple{{ .Prefix }}Initiator(opts ...{{ .Prefix }}InitiatorOption) (*Sim
 {{- $opid := .GoOperationID }}
 {{- $hasParams := .HasParams }}
 {{- $paramsTypeName := .ParamsTypeName }}
+{{- $prefix := $.Prefix }}
+{{- $prefixLower := $.PrefixLower }}
 
 {{- /* Determine if this operation is "simple" - single success content type, single JSON success response */}}
 {{- $simpleOp := isSimpleOperation . }}
@@ -43,19 +45,19 @@ func NewSimple{{ .Prefix }}Initiator(opts ...{{ .Prefix }}InitiatorOption) (*Sim
 {{- $successType := goTypeForContent $successContent }}
 {{- $errorResponse := errorResponseForOperation . }}
 
-// {{ $opid }} sends a {{ .Method }} {{ $.PrefixLower }} request and returns the parsed response.
+// {{ $opid }} sends a {{ .Method }} {{ $prefixLower }} request and returns the parsed response.
 {{ if .Summary }}// {{ .Summary }}{{ end }}
 {{- if $errorResponse }}
 {{- $errorContent := index $errorResponse.Contents 0 }}
 {{- $errorType := goTypeForContent $errorContent }}
-// On success, returns the response body. On HTTP error, returns *{{ $.Prefix }}HttpError[{{ $errorType }}].
-func (p *Simple{{ $.Prefix }}Initiator) {{ $opid }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, body {{ (index .Bodies 0).GoTypeName }}{{ end }}, reqEditors ...RequestEditorFn) ({{ $successType }}, error) {
+// On success, returns the response body. On HTTP error, returns *{{ $prefix }}HttpError[{{ $errorType }}].
+func (p *Simple{{ $prefix }}Initiator) {{ $opid }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, body {{ (index .Bodies 0).GoTypeName }}{{ end }}, reqEditors ...RequestEditorFn) ({{ $successType }}, error) {
 	var result {{ $successType }}
 {{- if .HasBody }}
 {{- $defaultBody := index .Bodies 0 }}
-	resp, err := p.{{ $.Prefix }}Initiator.{{ $opid }}{{ $defaultBody.FuncSuffix }}(ctx, targetURL{{ if $hasParams }}, params{{ end }}, body, reqEditors...)
+	resp, err := p.{{ $prefix }}Initiator.{{ $opid }}{{ $defaultBody.FuncSuffix }}(ctx, targetURL{{ if $hasParams }}, params{{ end }}, body, reqEditors...)
 {{- else }}
-	resp, err := p.{{ $.Prefix }}Initiator.{{ $opid }}(ctx, targetURL{{ if $hasParams }}, params{{ end }}, reqEditors...)
+	resp, err := p.{{ $prefix }}Initiator.{{ $opid }}(ctx, targetURL{{ if $hasParams }}, params{{ end }}, reqEditors...)
 {{- end }}
 	if err != nil {
 		return result, err
@@ -77,21 +79,21 @@ func (p *Simple{{ $.Prefix }}Initiator) {{ $opid }}(ctx context.Context, targetU
 	// Parse error response
 	var errBody {{ $errorType }}
 	_ = json.Unmarshal(rawBody, &errBody) // Best effort parse
-	return result, &{{ $.Prefix }}HttpError[{{ $errorType }}]{
+	return result, &{{ $prefix }}HttpError[{{ $errorType }}]{
 		StatusCode: resp.StatusCode,
 		Body:       errBody,
 		RawBody:    rawBody,
 	}
 }
 {{- else }}
-// On success, returns the response body. On HTTP error, returns *{{ $.Prefix }}HttpError[struct{}].
-func (p *Simple{{ $.Prefix }}Initiator) {{ $opid }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, body {{ (index .Bodies 0).GoTypeName }}{{ end }}, reqEditors ...RequestEditorFn) ({{ $successType }}, error) {
+// On success, returns the response body. On HTTP error, returns *{{ $prefix }}HttpError[struct{}].
+func (p *Simple{{ $prefix }}Initiator) {{ $opid }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, body {{ (index .Bodies 0).GoTypeName }}{{ end }}, reqEditors ...RequestEditorFn) ({{ $successType }}, error) {
 	var result {{ $successType }}
 {{- if .HasBody }}
 {{- $defaultBody := index .Bodies 0 }}
-	resp, err := p.{{ $.Prefix }}Initiator.{{ $opid }}{{ $defaultBody.FuncSuffix }}(ctx, targetURL{{ if $hasParams }}, params{{ end }}, body, reqEditors...)
+	resp, err := p.{{ $prefix }}Initiator.{{ $opid }}{{ $defaultBody.FuncSuffix }}(ctx, targetURL{{ if $hasParams }}, params{{ end }}, body, reqEditors...)
 {{- else }}
-	resp, err := p.{{ $.Prefix }}Initiator.{{ $opid }}(ctx, targetURL{{ if $hasParams }}, params{{ end }}, reqEditors...)
+	resp, err := p.{{ $prefix }}Initiator.{{ $opid }}(ctx, targetURL{{ if $hasParams }}, params{{ end }}, reqEditors...)
 {{- end }}
 	if err != nil {
 		return result, err
@@ -111,7 +113,7 @@ func (p *Simple{{ $.Prefix }}Initiator) {{ $opid }}(ctx context.Context, targetU
 	}
 
 	// No typed error response defined
-	return result, &{{ $.Prefix }}HttpError[struct{}]{
+	return result, &{{ $prefix }}HttpError[struct{}]{
 		StatusCode: resp.StatusCode,
 		RawBody:    rawBody,
 	}


### PR DESCRIPTION
Save ParamsTypeName as a local variable before entering nested range .Bodies loops in client and initiator interface templates, matching the pattern used by all other templates. Without this, $.ParamsTypeName fails because $ refers to the root context (a slice or struct) which has no such field, causing a template error when generating client code for operations with both params and a body.

Also normalize all initiator templates to consistently save $.Prefix and $.PrefixLower as $prefix/$prefixLower at the top of the range .Operations loop and use the saved variables throughout, instead of mixing direct root context access ($.Prefix) with saved variables.

Fixes #1