### PR TITLE
Fix form-urlencoded request body code generation

### DIFF
--- a/experimental/internal/codegen/configuration.go
+++ b/experimental/internal/codegen/configuration.go
@@ -152,6 +152,7 @@ func DefaultContentTypes() []string {
 	return []string{
 		`^application/json$`,
 		`^application/.*\+json$`,
+		`^application/x-www-form-urlencoded$`,
 	}
 }
 

--- a/experimental/internal/codegen/filter_test.go
+++ b/experimental/internal/codegen/filter_test.go
@@ -85,7 +85,7 @@ func gatherTestOps(t *testing.T) []*OperationDescriptor {
 	require.NoError(t, err)
 
 	tracker := NewParamUsageTracker()
-	ops, err := GatherOperations(doc, tracker)
+	ops, err := GatherOperations(doc, tracker, NewContentTypeMatcher(DefaultContentTypes()))
 	require.NoError(t, err)
 	return ops
 }

--- a/experimental/internal/codegen/initiatorgen.go
+++ b/experimental/internal/codegen/initiatorgen.go
@@ -132,7 +132,7 @@ func (g *InitiatorGenerator) GenerateRequestBodyTypes(ops []*OperationDescriptor
 
 	for _, op := range ops {
 		for _, body := range op.Bodies {
-			if !body.IsJSON {
+			if !body.GenerateTyped {
 				continue
 			}
 			var targetType string

--- a/experimental/internal/codegen/operation.go
+++ b/experimental/internal/codegen/operation.go
@@ -95,6 +95,27 @@ func (o *OperationDescriptor) DefaultBody() *RequestBodyDescriptor {
 	return nil
 }
 
+// DefaultTypedBody returns the first request body with GenerateTyped=true,
+// preferring the default body. Returns nil if no typed body exists.
+func (o *OperationDescriptor) DefaultTypedBody() *RequestBodyDescriptor {
+	for _, b := range o.Bodies {
+		if b.GenerateTyped && b.IsDefault {
+			return b
+		}
+	}
+	for _, b := range o.Bodies {
+		if b.GenerateTyped {
+			return b
+		}
+	}
+	return nil
+}
+
+// HasTypedBody returns true if at least one request body has GenerateTyped=true.
+func (o *OperationDescriptor) HasTypedBody() bool {
+	return o.DefaultTypedBody() != nil
+}
+
 // ParameterDescriptor describes a parameter in any location.
 type ParameterDescriptor struct {
 	Name     string // Original name from spec (e.g., "user_id")
@@ -160,8 +181,9 @@ type RequestBodyDescriptor struct {
 	NameTag    string // "JSON", "Formdata", "Multipart", "Text", etc.
 	GoTypeName string // "{OperationID}JSONBody", etc.
 	FuncSuffix string // "", "WithJSONBody", "WithFormBody" (empty for default)
-	IsDefault  bool   // Is this the default body type?
-	IsJSON     bool   // Is this a JSON content type?
+	IsDefault     bool // Is this the default body type?
+	IsFormEncoded bool // Is this application/x-www-form-urlencoded?
+	GenerateTyped bool // Generate typed methods for this body (based on content-types config)
 
 	// Encoding options for form data
 	Encoding map[string]RequestBodyEncoding

--- a/experimental/internal/codegen/templates/files/client/interface.go.tmpl
+++ b/experimental/internal/codegen/templates/files/client/interface.go.tmpl
@@ -10,7 +10,7 @@ type ClientInterface interface {
 	// {{ $opid }}{{ if .HasBody }}WithBody{{ end }} makes a {{ .Method }} request to {{ .Path }}
 	{{ $opid }}{{ if .HasBody }}WithBody{{ end }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, contentType string, body io.Reader{{ end }}, reqEditors ...RequestEditorFn) (*http.Response, error)
 {{- range .Bodies }}
-{{- if .IsJSON }}
+{{- if .GenerateTyped }}
 	{{ $opid }}{{ .FuncSuffix }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error)
 {{- end }}
 {{- end }}

--- a/experimental/internal/codegen/templates/files/client/methods.go.tmpl
+++ b/experimental/internal/codegen/templates/files/client/methods.go.tmpl
@@ -21,9 +21,9 @@ func (c *Client) {{ $opid }}{{ if .HasBody }}WithBody{{ end }}(ctx context.Conte
 	return c.Client.Do(req)
 }
 {{- range .Bodies }}
-{{- if .IsJSON }}
+{{- if .GenerateTyped }}
 
-// {{ $opid }}{{ .FuncSuffix }} makes a {{ $op.Method }} request to {{ $op.Path }} with JSON body
+// {{ $opid }}{{ .FuncSuffix }} makes a {{ $op.Method }} request to {{ $op.Path }} with {{ .ContentType }} body
 func (c *Client) {{ $opid }}{{ .FuncSuffix }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := New{{ $opid }}Request{{ .FuncSuffix }}(c.Server{{ range $pathParams }}, {{ .GoVariableName }}{{ end }}{{ if $hasParams }}, params{{ end }}, body)
 	if err != nil {

--- a/experimental/internal/codegen/templates/files/client/request_builders.go.tmpl
+++ b/experimental/internal/codegen/templates/files/client/request_builders.go.tmpl
@@ -10,18 +10,26 @@
 {{- $headerParams := .HeaderParams }}
 {{- $cookieParams := .CookieParams }}
 
-{{- /* Generate typed body request builders for JSON bodies */ -}}
+{{- /* Generate typed body request builders for content types matching config */ -}}
 {{- range .Bodies }}
-{{- if .IsJSON }}
+{{- if .GenerateTyped }}
 
 // New{{ $opid }}Request{{ .FuncSuffix }} creates a {{ $op.Method }} request for {{ $op.Path }} with {{ .ContentType }} body
 func New{{ $opid }}Request{{ .FuncSuffix }}(server string{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}) (*http.Request, error) {
 	var bodyReader io.Reader
+{{- if .IsFormEncoded }}
+	values, err := marshalForm(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(values.Encode())
+{{- else }}
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
+{{- end }}
 	return New{{ $opid }}RequestWithBody(server{{ range $pathParams }}, {{ .GoVariableName }}{{ end }}{{ if $hasParams }}, params{{ end }}, "{{ .ContentType }}", bodyReader)
 }
 {{- end }}

--- a/experimental/internal/codegen/templates/files/client/simple.go.tmpl
+++ b/experimental/internal/codegen/templates/files/client/simple.go.tmpl
@@ -49,11 +49,11 @@ func NewSimpleClient(server string, opts ...ClientOption) (*SimpleClient, error)
 {{- $errorContent := index $errorResponse.Contents 0 }}
 {{- $errorType := goTypeForContent $errorContent }}
 // On success, returns the response body. On HTTP error, returns *ClientHttpError[{{ $errorType }}].
-func (c *SimpleClient) {{ $opid }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, body {{ (index .Bodies 0).GoTypeName }}{{ end }}, reqEditors ...RequestEditorFn) ({{ $successType }}, error) {
+{{- $typedBody := defaultTypedBody $op }}
+func (c *SimpleClient) {{ $opid }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if $typedBody }}, body {{ $typedBody.GoTypeName }}{{ end }}, reqEditors ...RequestEditorFn) ({{ $successType }}, error) {
 	var result {{ $successType }}
-{{- if .HasBody }}
-{{- $defaultBody := index .Bodies 0 }}
-	resp, err := c.Client.{{ $opid }}{{ $defaultBody.FuncSuffix }}(ctx{{ range $pathParams }}, {{ .GoVariableName }}{{ end }}{{ if $hasParams }}, params{{ end }}, body, reqEditors...)
+{{- if $typedBody }}
+	resp, err := c.Client.{{ $opid }}{{ $typedBody.FuncSuffix }}(ctx{{ range $pathParams }}, {{ .GoVariableName }}{{ end }}{{ if $hasParams }}, params{{ end }}, body, reqEditors...)
 {{- else }}
 	resp, err := c.Client.{{ $opid }}(ctx{{ range $pathParams }}, {{ .GoVariableName }}{{ end }}{{ if $hasParams }}, params{{ end }}, reqEditors...)
 {{- end }}
@@ -85,11 +85,11 @@ func (c *SimpleClient) {{ $opid }}(ctx context.Context{{ range $pathParams }}, {
 }
 {{- else }}
 // On success, returns the response body. On HTTP error, returns *ClientHttpError[struct{}].
-func (c *SimpleClient) {{ $opid }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, body {{ (index .Bodies 0).GoTypeName }}{{ end }}, reqEditors ...RequestEditorFn) ({{ $successType }}, error) {
+{{- $typedBody := defaultTypedBody $op }}
+func (c *SimpleClient) {{ $opid }}(ctx context.Context{{ range $pathParams }}, {{ .GoVariableName }} {{ .TypeDecl }}{{ end }}{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if $typedBody }}, body {{ $typedBody.GoTypeName }}{{ end }}, reqEditors ...RequestEditorFn) ({{ $successType }}, error) {
 	var result {{ $successType }}
-{{- if .HasBody }}
-{{- $defaultBody := index .Bodies 0 }}
-	resp, err := c.Client.{{ $opid }}{{ $defaultBody.FuncSuffix }}(ctx{{ range $pathParams }}, {{ .GoVariableName }}{{ end }}{{ if $hasParams }}, params{{ end }}, body, reqEditors...)
+{{- if $typedBody }}
+	resp, err := c.Client.{{ $opid }}{{ $typedBody.FuncSuffix }}(ctx{{ range $pathParams }}, {{ .GoVariableName }}{{ end }}{{ if $hasParams }}, params{{ end }}, body, reqEditors...)
 {{- else }}
 	resp, err := c.Client.{{ $opid }}(ctx{{ range $pathParams }}, {{ .GoVariableName }}{{ end }}{{ if $hasParams }}, params{{ end }}, reqEditors...)
 {{- end }}

--- a/experimental/internal/codegen/templates/files/helpers/marshal_form.go.tmpl
+++ b/experimental/internal/codegen/templates/files/helpers/marshal_form.go.tmpl
@@ -1,0 +1,62 @@
+{{/* marshalForm helper - marshals a struct into url.Values using json tags */}}
+
+// marshalForm marshals a struct into url.Values using the struct's json tags
+// as field names. It handles nested structs, slices, pointers, and
+// AdditionalProperties maps.
+func marshalForm(body interface{}) (url.Values, error) {
+	ptrVal := reflect.Indirect(reflect.ValueOf(body))
+	if ptrVal.Kind() != reflect.Struct {
+		return nil, errors.New("form data body should be a struct")
+	}
+	tValue := ptrVal.Type()
+	result := make(url.Values)
+	for i := 0; i < tValue.NumField(); i++ {
+		field := ptrVal.Field(i)
+		tag := tValue.Field(i).Tag.Get("json")
+		if !field.CanInterface() || tag == "-" {
+			continue
+		}
+		omitEmpty := strings.HasSuffix(tag, ",omitempty")
+		if omitEmpty && field.IsZero() {
+			continue
+		}
+		tag = strings.Split(tag, ",")[0]
+		marshalFormImpl(field, result, tag)
+	}
+	return result, nil
+}
+
+func marshalFormImpl(v reflect.Value, result url.Values, name string) {
+	switch v.Kind() {
+	case reflect.Interface, reflect.Ptr:
+		if !v.IsNil() {
+			marshalFormImpl(v.Elem(), result, name)
+		}
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			marshalFormImpl(v.Index(i), result, fmt.Sprintf("%s[%v]", name, i))
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Type().Field(i)
+			tag := field.Tag.Get("json")
+			if field.Name == "AdditionalProperties" && tag == "-" {
+				mapField := v.Field(i)
+				if mapField.Kind() == reflect.Map {
+					iter := mapField.MapRange()
+					for iter.Next() {
+						marshalFormImpl(iter.Value(), result, fmt.Sprintf("%s[%s]", name, iter.Key().String()))
+					}
+				}
+				continue
+			}
+			if !v.Field(i).CanInterface() || tag == "-" {
+				continue
+			}
+			tag = strings.Split(tag, ",")[0]
+			marshalFormImpl(v.Field(i), result, fmt.Sprintf("%s[%s]", name, tag))
+		}
+	default:
+		result[name] = append(result[name], fmt.Sprint(v.Interface()))
+	}
+}

--- a/experimental/internal/codegen/templates/files/initiator/interface.go.tmpl
+++ b/experimental/internal/codegen/templates/files/initiator/interface.go.tmpl
@@ -11,7 +11,7 @@ type {{ .Prefix }}InitiatorInterface interface {
 	// {{ $opid }}{{ if .HasBody }}WithBody{{ end }} sends a {{ .Method }} {{ $prefixLower }} request
 	{{ $opid }}{{ if .HasBody }}WithBody{{ end }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}{{ if .HasBody }}, contentType string, body io.Reader{{ end }}, reqEditors ...RequestEditorFn) (*http.Response, error)
 {{- range .Bodies }}
-{{- if .IsJSON }}
+{{- if .GenerateTyped }}
 	{{ $opid }}{{ .FuncSuffix }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error)
 {{- end }}
 {{- end }}

--- a/experimental/internal/codegen/templates/files/initiator/methods.go.tmpl
+++ b/experimental/internal/codegen/templates/files/initiator/methods.go.tmpl
@@ -23,9 +23,9 @@ func (p *{{ $prefix }}Initiator) {{ $opid }}{{ if .HasBody }}WithBody{{ end }}(c
 	return p.Client.Do(req)
 }
 {{- range .Bodies }}
-{{- if .IsJSON }}
+{{- if .GenerateTyped }}
 
-// {{ $opid }}{{ .FuncSuffix }} sends a {{ $op.Method }} {{ $prefixLower }} request with JSON body
+// {{ $opid }}{{ .FuncSuffix }} sends a {{ $op.Method }} {{ $prefixLower }} request with {{ .ContentType }} body
 func (p *{{ $prefix }}Initiator) {{ $opid }}{{ .FuncSuffix }}(ctx context.Context, targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := New{{ $opid }}{{ $prefix }}Request{{ .FuncSuffix }}(targetURL{{ if $hasParams }}, params{{ end }}, body)
 	if err != nil {

--- a/experimental/internal/codegen/templates/files/initiator/request_builders.go.tmpl
+++ b/experimental/internal/codegen/templates/files/initiator/request_builders.go.tmpl
@@ -12,18 +12,26 @@
 {{- $prefix := $.Prefix }}
 {{- $prefixLower := $.PrefixLower }}
 
-{{- /* Generate typed body request builders for JSON bodies */ -}}
+{{- /* Generate typed body request builders for content types matching config */ -}}
 {{- range .Bodies }}
-{{- if .IsJSON }}
+{{- if .GenerateTyped }}
 
 // New{{ $opid }}{{ $prefix }}Request{{ .FuncSuffix }} creates a {{ $op.Method }} request for the {{ $prefixLower }} with {{ .ContentType }} body
 func New{{ $opid }}{{ $prefix }}Request{{ .FuncSuffix }}(targetURL string{{ if $hasParams }}, params *{{ $paramsTypeName }}{{ end }}, body {{ .GoTypeName }}) (*http.Request, error) {
 	var bodyReader io.Reader
+{{- if .IsFormEncoded }}
+	values, err := marshalForm(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(values.Encode())
+{{- else }}
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
+{{- end }}
 	return New{{ $opid }}{{ $prefix }}RequestWithBody(targetURL{{ if $hasParams }}, params{{ end }}, "{{ .ContentType }}", bodyReader)
 }
 {{- end }}

--- a/experimental/internal/codegen/templates/registry.go
+++ b/experimental/internal/codegen/templates/registry.go
@@ -59,6 +59,27 @@ var TypeTemplates = map[string]TypeTemplate{
 	},
 }
 
+// HelperTemplate defines a template for a helper function that is conditionally included.
+type HelperTemplate struct {
+	Name     string   // Template name (e.g., "marshal_form")
+	Imports  []Import // Required imports for this function
+	Template string   // Template path in embedded FS (e.g., "helpers/marshal_form.go.tmpl")
+}
+
+// MarshalFormHelperTemplate is the template for the marshalForm helper function.
+// This is included when any operation has a form-encoded typed request body.
+var MarshalFormHelperTemplate = HelperTemplate{
+	Name: "marshal_form",
+	Imports: []Import{
+		{Path: "errors"},
+		{Path: "fmt"},
+		{Path: "net/url"},
+		{Path: "reflect"},
+		{Path: "strings"},
+	},
+	Template: "helpers/marshal_form.go.tmpl",
+}
+
 // ParamTemplate defines a template for a parameter styling/binding function.
 type ParamTemplate struct {
 	Name     string   // Function name (e.g., "StyleSimpleParam")
@@ -827,9 +848,11 @@ var InitiatorTemplates = map[string]InitiatorTemplate{
 		Imports: []Import{
 			{Path: "bytes"},
 			{Path: "encoding/json"},
+			{Path: "fmt"},
 			{Path: "io"},
 			{Path: "net/http"},
 			{Path: "net/url"},
+			{Path: "strings"},
 		},
 		Template: "initiator/request_builders.go.tmpl",
 	},
@@ -892,6 +915,7 @@ var ClientTemplates = map[string]ClientTemplate{
 			{Path: "io"},
 			{Path: "net/http"},
 			{Path: "net/url"},
+			{Path: "strings"},
 		},
 		Template: "client/request_builders.go.tmpl",
 	},


### PR DESCRIPTION
Operations with application/x-www-form-urlencoded request bodies produced uncompilable code: the SimpleClient referenced undefined typed body structs and methods because the code generator only recognized application/json content types.

This change introduces a config-driven ContentTypeMatcher that determines which content types get typed request body methods, replacing the hard-coded IsJSON checks. form-urlencoded is now included in the default content-type list alongside JSON.

For form-encoded bodies, serialization uses a new marshalForm helper (reflection-based, using json struct tags) instead of json.Marshal, avoiding a JSON round-trip that would produce incorrect form encoding.

Key changes:
- Replace RequestBodyDescriptor.IsJSON with GenerateTyped (config-driven) and IsFormEncoded (content-type flag)
- Add ContentTypeMatcher to operationGatherer and all Gather*Operations call sites
- Add DefaultTypedBody/HasTypedBody to OperationDescriptor so the SimpleClient template picks the correct typed body
- Add marshalForm/marshalFormImpl helper template for struct-to-url.Values serialization
- Update client, initiator, and simple-client templates to branch on IsFormEncoded vs JSON for body serialization

Closes #2