### PR TITLE
Fix schema filtering, external ApplyDefaults, and primitive component…

### DIFF
--- a/experimental/internal/codegen/clientgen_test.go
+++ b/experimental/internal/codegen/clientgen_test.go
@@ -20,7 +20,7 @@ func TestClientGenerator(t *testing.T) {
 
 	// Gather schemas to build schema index
 	contentTypeMatcher := NewContentTypeMatcher(DefaultContentTypes())
-	schemas, err := GatherSchemas(doc, contentTypeMatcher)
+	schemas, err := GatherSchemas(doc, contentTypeMatcher, OutputOptions{})
 	require.NoError(t, err, "Failed to gather schemas")
 
 	// Compute names for schemas
@@ -90,7 +90,7 @@ func TestClientGenerator_FormEncoded(t *testing.T) {
 	require.NoError(t, err, "Failed to parse comprehensive spec")
 
 	contentTypeMatcher := NewContentTypeMatcher(DefaultContentTypes())
-	schemas, err := GatherSchemas(doc, contentTypeMatcher)
+	schemas, err := GatherSchemas(doc, contentTypeMatcher, OutputOptions{})
 	require.NoError(t, err, "Failed to gather schemas")
 
 	converter := NewNameConverter(NameMangling{}, NameSubstitutions{})

--- a/experimental/internal/codegen/configuration.go
+++ b/experimental/internal/codegen/configuration.go
@@ -52,6 +52,10 @@ type OutputOptions struct {
 	ExcludeOperationIDs []string `yaml:"exclude-operation-ids,omitempty"`
 	// ExcludeSchemas excludes schemas with the given names from generation. Ignored when empty.
 	ExcludeSchemas []string `yaml:"exclude-schemas,omitempty"`
+	// PruneUnreferencedSchemas removes component schemas that are not $ref'd by any other
+	// gathered schema. When combined with tag/operation filtering, this effectively removes
+	// schemas that are only used by excluded operations.
+	PruneUnreferencedSchemas bool `yaml:"prune-unreferenced-schemas,omitempty"`
 }
 
 // ModelsPackage specifies an external package containing the model types.

--- a/experimental/internal/codegen/filter_test.go
+++ b/experimental/internal/codegen/filter_test.go
@@ -195,7 +195,7 @@ func TestFilterSchemasByName(t *testing.T) {
 	require.NoError(t, err)
 
 	matcher := NewContentTypeMatcher(DefaultContentTypes())
-	schemas, err := GatherSchemas(doc, matcher)
+	schemas, err := GatherSchemas(doc, matcher, OutputOptions{})
 	require.NoError(t, err)
 
 	// Count component schemas
@@ -228,7 +228,7 @@ func TestFilterSchemasByName_Empty(t *testing.T) {
 	require.NoError(t, err)
 
 	matcher := NewContentTypeMatcher(DefaultContentTypes())
-	schemas, err := GatherSchemas(doc, matcher)
+	schemas, err := GatherSchemas(doc, matcher, OutputOptions{})
 	require.NoError(t, err)
 
 	filtered := FilterSchemasByName(schemas, nil)
@@ -298,6 +298,74 @@ func TestFilterIntegration_GenerateWithExcludeSchemas(t *testing.T) {
 	assert.Contains(t, code, "type Settings struct")
 	// Pet type should be excluded
 	assert.NotContains(t, code, "type Pet struct")
+}
+
+// TestFilterIntegration_IncludeTagsFiltersSchemas verifies that when include-tags is used,
+// only schemas referenced by the included operations are generated.
+// This is the behavioral test for https://github.com/oapi-codegen/oapi-codegen-exp/issues/3
+func TestFilterIntegration_IncludeTagsFiltersSchemas(t *testing.T) {
+	doc, err := libopenapi.NewDocument([]byte(filterTestSpec))
+	require.NoError(t, err)
+
+	cfg := Configuration{
+		PackageName: "testpkg",
+		Generation: GenerationOptions{
+			Client: true,
+		},
+		OutputOptions: OutputOptions{
+			IncludeTags:              []string{"users"},
+			PruneUnreferencedSchemas: true,
+		},
+	}
+
+	code, err := Generate(doc, []byte(filterTestSpec), cfg)
+	require.NoError(t, err)
+
+	t.Logf("Generated code:\n%s", code)
+
+	// Operations: only ListUsers should be included
+	assert.Contains(t, code, "ListUsers(ctx context.Context")
+	assert.NotContains(t, code, "ListPets(ctx context.Context")
+	assert.NotContains(t, code, "GetSettings(ctx context.Context")
+
+	// Schemas: only User (used by listUsers) should be generated.
+	// Pet and Settings are only used by excluded operations and should NOT be generated.
+	assert.Contains(t, code, "type User struct")
+	assert.NotContains(t, code, "type Pet struct", "Pet schema should not be generated when only 'users' tag is included")
+	assert.NotContains(t, code, "type Settings struct", "Settings schema should not be generated when only 'users' tag is included")
+}
+
+// TestFilterIntegration_ExcludeTagsFiltersSchemas verifies that when exclude-tags is used,
+// schemas only referenced by excluded operations are not generated.
+func TestFilterIntegration_ExcludeTagsFiltersSchemas(t *testing.T) {
+	doc, err := libopenapi.NewDocument([]byte(filterTestSpec))
+	require.NoError(t, err)
+
+	cfg := Configuration{
+		PackageName: "testpkg",
+		Generation: GenerationOptions{
+			Client: true,
+		},
+		OutputOptions: OutputOptions{
+			ExcludeTags:              []string{"admin"},
+			PruneUnreferencedSchemas: true,
+		},
+	}
+
+	code, err := Generate(doc, []byte(filterTestSpec), cfg)
+	require.NoError(t, err)
+
+	t.Logf("Generated code:\n%s", code)
+
+	// Operations: users and pets should be included, admin should not
+	assert.Contains(t, code, "ListUsers(ctx context.Context")
+	assert.Contains(t, code, "ListPets(ctx context.Context")
+	assert.NotContains(t, code, "GetSettings(ctx context.Context")
+
+	// Schemas: User and Pet should be generated, Settings (admin-only) should not
+	assert.Contains(t, code, "type User struct")
+	assert.Contains(t, code, "type Pet struct")
+	assert.NotContains(t, code, "type Settings struct", "Settings schema should not be generated when 'admin' tag is excluded")
 }
 
 func TestFilterIntegration_ServerWithIncludeTags(t *testing.T) {

--- a/experimental/internal/codegen/issue3_test.go
+++ b/experimental/internal/codegen/issue3_test.go
@@ -1,0 +1,264 @@
+package codegen
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for https://github.com/oapi-codegen/oapi-codegen-exp/issues/3
+
+// TestApplyDefaults_ExternalTypes verifies that generated ApplyDefaults methods
+// do not blindly call .ApplyDefaults() on external types. External types may not
+// have this method, and calling it would cause compilation errors.
+//
+// The fix should use reflection to call ApplyDefaults only if it exists on the
+// external type.
+func TestApplyDefaults_ExternalTypes(t *testing.T) {
+	specData, err := os.ReadFile("test/external_ref/spec.yaml")
+	require.NoError(t, err)
+
+	docConfig := datamodel.NewDocumentConfiguration()
+	docConfig.SkipExternalRefResolution = true
+
+	doc, err := libopenapi.NewDocumentWithConfiguration(specData, docConfig)
+	require.NoError(t, err)
+
+	cfg := Configuration{
+		PackageName: "externalref",
+		ImportMapping: map[string]string{
+			"./packagea/spec.yaml": "github.com/oapi-codegen/oapi-codegen-exp/experimental/internal/codegen/test/external_ref/packagea",
+			"./packageb/spec.yaml": "github.com/oapi-codegen/oapi-codegen-exp/experimental/internal/codegen/test/external_ref/packageb",
+		},
+	}
+
+	code, err := Generate(doc, nil, cfg)
+	require.NoError(t, err)
+
+	t.Logf("Generated code:\n%s", code)
+
+	// The Container struct should exist and reference external types
+	assert.Contains(t, code, "type Container struct")
+
+	// ApplyDefaults should be generated for Container
+	assert.Contains(t, code, "func (s *Container) ApplyDefaults()")
+
+	// The ApplyDefaults method should NOT contain direct calls to .ApplyDefaults()
+	// on external types, because we cannot know at codegen time whether external
+	// types have this method. Instead, it should use reflection or a type assertion
+	// to check if the method exists before calling it.
+	//
+	// Current (broken) behavior generates:
+	//   if s.ObjectA != nil { s.ObjectA.ApplyDefaults() }
+	//   if s.ObjectB != nil { s.ObjectB.ApplyDefaults() }
+	//
+	// This causes compilation errors when external types don't have ApplyDefaults().
+	// The fix should use reflection to call it conditionally.
+	applyDefaultsSection := extractApplyDefaultsMethod(t, code, "Container")
+	require.NotEmpty(t, applyDefaultsSection, "should have found ApplyDefaults method for Container")
+
+	// It should NOT directly call .ApplyDefaults() on external type fields
+	assert.NotContains(t, applyDefaultsSection, "s.ObjectA.ApplyDefaults()",
+		"should not directly call ApplyDefaults() on external type ObjectA - use reflection instead")
+	assert.NotContains(t, applyDefaultsSection, "s.ObjectB.ApplyDefaults()",
+		"should not directly call ApplyDefaults() on external type ObjectB - use reflection instead")
+
+	// It SHOULD use reflection to conditionally call ApplyDefaults
+	assert.Contains(t, code, "reflect", "should import reflect package for calling ApplyDefaults on external types")
+}
+
+// TestRefProperties_NoRedeclaration verifies that response models composed of
+// properties with $ref do not cause type redeclarations.
+func TestRefProperties_NoRedeclaration(t *testing.T) {
+	const spec = `openapi: "3.1.0"
+info:
+  title: Ref Redeclaration Test
+  version: "1.0"
+paths:
+  /order:
+    get:
+      operationId: getOrder
+      tags:
+        - orders
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  buyer:
+                    $ref: '#/components/schemas/Person'
+                  seller:
+                    $ref: '#/components/schemas/Person'
+                  item:
+                    $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Person:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+    Item:
+      type: object
+      properties:
+        title:
+          type: string
+        price:
+          type: number
+`
+
+	doc, err := libopenapi.NewDocument([]byte(spec))
+	require.NoError(t, err)
+
+	cfg := Configuration{
+		PackageName: "testpkg",
+	}
+
+	code, err := Generate(doc, nil, cfg)
+	require.NoError(t, err)
+
+	t.Logf("Generated code:\n%s", code)
+
+	// Person and Item component schemas should each be declared exactly once
+	personCount := strings.Count(code, "type Person struct")
+	assert.Equal(t, 1, personCount,
+		"Person struct should be declared exactly once, got %d", personCount)
+
+	itemCount := strings.Count(code, "type Item struct")
+	assert.Equal(t, 1, itemCount,
+		"Item struct should be declared exactly once, got %d", itemCount)
+
+	// The response type for getOrder should exist
+	// (the exact name depends on naming conventions, but should contain "GetOrder" and "Response")
+	assert.Contains(t, code, "GetOrder")
+
+	// The code should compile (basic check: no duplicate type declarations)
+	// Count all "type X struct" declarations
+	typeDecls := countTypeDeclarations(code)
+	for typeName, count := range typeDecls {
+		assert.Equal(t, 1, count,
+			"type %s should be declared exactly once, got %d", typeName, count)
+	}
+}
+
+// TestRefProperties_SharedSchemaAcrossEndpoints verifies that when multiple
+// endpoints reference the same schema, it's only declared once.
+func TestRefProperties_SharedSchemaAcrossEndpoints(t *testing.T) {
+	const spec = `openapi: "3.1.0"
+info:
+  title: Shared Schema Test
+  version: "1.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  users:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/User'
+  /users/{id}:
+    get:
+      operationId: getUser
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+`
+
+	doc, err := libopenapi.NewDocument([]byte(spec))
+	require.NoError(t, err)
+
+	cfg := Configuration{
+		PackageName: "testpkg",
+	}
+
+	code, err := Generate(doc, nil, cfg)
+	require.NoError(t, err)
+
+	t.Logf("Generated code:\n%s", code)
+
+	// User struct should be declared exactly once even though it's referenced
+	// from multiple endpoints
+	userCount := strings.Count(code, "type User struct")
+	assert.Equal(t, 1, userCount,
+		"User struct should be declared exactly once, got %d", userCount)
+}
+
+// extractApplyDefaultsMethod extracts the ApplyDefaults method body for a given type name.
+func extractApplyDefaultsMethod(t *testing.T, code, typeName string) string {
+	t.Helper()
+
+	// Look for "func (s *TypeName) ApplyDefaults()" and extract until the closing "}"
+	marker := "func (s *" + typeName + ") ApplyDefaults()"
+	idx := strings.Index(code, marker)
+	if idx == -1 {
+		// Also try with "u" receiver for union types
+		marker = "func (u *" + typeName + ") ApplyDefaults()"
+		idx = strings.Index(code, marker)
+	}
+	if idx == -1 {
+		return ""
+	}
+
+	// Find the matching closing brace by counting braces
+	rest := code[idx:]
+	braceCount := 0
+	for i, ch := range rest {
+		if ch == '{' {
+			braceCount++
+		} else if ch == '}' {
+			braceCount--
+			if braceCount == 0 {
+				return rest[:i+1]
+			}
+		}
+	}
+	return ""
+}
+
+// countTypeDeclarations counts occurrences of "type X struct" declarations.
+func countTypeDeclarations(code string) map[string]int {
+	counts := make(map[string]int)
+	lines := strings.Split(code, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "type ") && strings.Contains(line, " struct") {
+			// Extract the type name
+			parts := strings.Fields(line)
+			if len(parts) >= 3 && parts[2] == "struct" {
+				counts[parts[1]]++
+			}
+		}
+	}
+	return counts
+}

--- a/experimental/internal/codegen/test/comprehensive/output/comprehensive.gen.go
+++ b/experimental/internal/codegen/test/comprehensive/output/comprehensive.gen.go
@@ -1577,6 +1577,16 @@ type TypeArray31 struct {
 func (s *TypeArray31) ApplyDefaults() {
 }
 
+// #/components/schemas/PrefixItems31
+type PrefixItems31 = []string
+
+// #/components/schemas/EmptySchema
+type EmptySchema = any
+
+// #/components/schemas/AnyValue
+// Accepts any JSON value
+type AnyValue = any
+
 // #/components/schemas/ExplicitAny
 type ExplicitAny = Nullable[string]
 

--- a/experimental/internal/codegen/test/external_ref/doc.go
+++ b/experimental/internal/codegen/test/external_ref/doc.go
@@ -1,0 +1,3 @@
+package externalref
+
+//go:generate go run ../../../../cmd/oapi-codegen -config config.yaml -output spec.gen.go spec.yaml

--- a/experimental/internal/codegen/test/external_ref/packagea/doc.go
+++ b/experimental/internal/codegen/test/external_ref/packagea/doc.go
@@ -1,0 +1,3 @@
+package packagea
+
+//go:generate go run ../../../../../cmd/oapi-codegen -config config.yaml -output spec.gen.go spec.yaml

--- a/experimental/internal/codegen/test/external_ref/packagea/spec.yaml
+++ b/experimental/internal/codegen/test/external_ref/packagea/spec.yaml
@@ -2,7 +2,61 @@ openapi: "3.1.0"
 info:
   title: Package A
   version: "1.0"
-paths: {}
+paths:
+  /references_local_models_with_external_fields:
+    post:
+      operationId: referencesLocalModelsWithExternalFields
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Employee'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Employee'
+  /defines_models_with_external_fields:
+    post:
+      operationId: definesModelsWithExternalFields
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - address
+                - occupation
+              properties:
+                name:
+                  $ref: ../packageb/spec.yaml#/components/schemas/Name
+                address:
+                  $ref: ../packageb/spec.yaml#/components/schemas/Address
+                occupation:
+                  $ref: ../packageb/spec.yaml#/components/schemas/Occupation
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - name
+                  - address
+                  - occupation
+                properties:
+                  name:
+                    $ref: ../packageb/spec.yaml#/components/schemas/Name
+                  address:
+                    $ref: ../packageb/spec.yaml#/components/schemas/Address
+                  occupation:
+                    $ref: ../packageb/spec.yaml#/components/schemas/Occupation
 components:
   schemas:
     ObjectA:
@@ -12,3 +66,16 @@ components:
           type: string
         object_b:
           $ref: ../packageb/spec.yaml#/components/schemas/ObjectB
+    Employee:
+      type: object
+      required:
+        - name
+        - address
+        - occupation
+      properties:
+        name:
+          $ref: ../packageb/spec.yaml#/components/schemas/Name
+        address:
+          $ref: ../packageb/spec.yaml#/components/schemas/Address
+        occupation:
+          $ref: ../packageb/spec.yaml#/components/schemas/Occupation

--- a/experimental/internal/codegen/test/external_ref/packageb/doc.go
+++ b/experimental/internal/codegen/test/external_ref/packageb/doc.go
@@ -1,0 +1,3 @@
+package packageb
+
+//go:generate go run ../../../../../cmd/oapi-codegen -config config.yaml -output spec.gen.go spec.yaml

--- a/experimental/internal/codegen/test/external_ref/packageb/spec.yaml
+++ b/experimental/internal/codegen/test/external_ref/packageb/spec.yaml
@@ -10,3 +10,9 @@ components:
       properties:
         name:
           type: string
+    Name:
+      type: string
+    Address:
+      type: string
+    Occupation:
+      type: string

--- a/experimental/internal/codegen/test/issues/issue_1039/output/types.gen.go
+++ b/experimental/internal/codegen/test/issues/issue_1039/output/types.gen.go
@@ -18,7 +18,7 @@ import (
 type PatchRequest struct {
 	SimpleRequiredNullable    SimpleRequiredNullable            `json:"simple_required_nullable" form:"simple_required_nullable"`
 	SimpleOptionalNullable    SimpleOptionalNullable            `json:"simple_optional_nullable,omitempty" form:"simple_optional_nullable,omitempty"`
-	SimpleOptionalNonNullable *any                              `json:"simple_optional_non_nullable,omitempty" form:"simple_optional_non_nullable,omitempty"`
+	SimpleOptionalNonNullable *SimpleOptionalNonNullable        `json:"simple_optional_non_nullable,omitempty" form:"simple_optional_non_nullable,omitempty"`
 	ComplexRequiredNullable   Nullable[ComplexRequiredNullable] `json:"complex_required_nullable" form:"complex_required_nullable"`
 	ComplexOptionalNullable   Nullable[ComplexOptionalNullable] `json:"complex_optional_nullable,omitempty" form:"complex_optional_nullable,omitempty"`
 	AdditionalProperties      map[string]any                    `json:"-"`
@@ -69,7 +69,7 @@ func (s *PatchRequest) UnmarshalJSON(data []byte) error {
 		}
 	}
 	if v, ok := raw["simple_optional_non_nullable"]; ok {
-		var val any
+		var val SimpleOptionalNonNullable
 		if err := json.Unmarshal(v, &val); err != nil {
 			return err
 		}
@@ -112,6 +112,10 @@ type SimpleRequiredNullable = Nullable[int]
 // #/components/schemas/simple_optional_nullable
 // Simple optional and nullable
 type SimpleOptionalNullable = Nullable[int]
+
+// #/components/schemas/simple_optional_non_nullable
+// Simple optional and non nullable
+type SimpleOptionalNonNullable = string
 
 // #/components/schemas/complex_required_nullable
 // Complex required and nullable

--- a/experimental/internal/codegen/test/issues/issue_579/output/types.gen.go
+++ b/experimental/internal/codegen/test/issues/issue_579/output/types.gen.go
@@ -15,13 +15,16 @@ import (
 
 // #/components/schemas/Pet
 type Pet struct {
-	Born   *any  `json:"born,omitempty" form:"born,omitempty"`
-	BornAt *Date `json:"born_at,omitempty" form:"born_at,omitempty"`
+	Born   *AliasedDate `json:"born,omitempty" form:"born,omitempty"`
+	BornAt *Date        `json:"born_at,omitempty" form:"born_at,omitempty"`
 }
 
 // ApplyDefaults sets default values for fields that are nil.
 func (s *Pet) ApplyDefaults() {
 }
+
+// #/components/schemas/AliasedDate
+type AliasedDate = Date
 
 // Base64-encoded, gzip-compressed OpenAPI spec.
 var openAPISpecJSON = []string{

--- a/experimental/internal/codegen/typegen.go
+++ b/experimental/internal/codegen/typegen.go
@@ -400,6 +400,7 @@ type StructField struct {
 	Doc             string // Field documentation
 	Default         string // Go literal for default value (empty if no default)
 	IsStruct        bool   // True if this field is a struct type (for recursive ApplyDefaults)
+	IsExternal      bool   // True if this field references an external type (ApplyDefaults via reflection)
 	IsNullableAlias bool   // True if type is a type alias to Nullable[T] (don't wrap or pointer)
 	Order           *int   // Optional field ordering (lower values come first)
 }
@@ -443,7 +444,7 @@ func (g *TypeGenerator) GenerateStructFields(desc *SchemaDescriptor) []StructFie
 				// External reference - use import mapping
 				tempDesc := &SchemaDescriptor{Ref: ref}
 				propType = g.externalRefType(tempDesc)
-				field.IsStruct = true // external references are typically to struct types
+				field.IsExternal = true // external references need reflection-based ApplyDefaults
 			} else if target, ok := g.schemaIndex[ref]; ok {
 				propType = target.ShortName
 				// Only set IsStruct if the referenced schema has ApplyDefaults


### PR DESCRIPTION
… aliases

Fixes: #3

1. Schema filtering by tags/operation IDs: GatherSchemas now accepts OutputOptions and skips operations excluded by tag or operation ID filters. A new prune-unreferenced-schemas option removes component schemas that are not ref'd by any gathered schema.

2. ApplyDefaults on external types: External ref fields now use reflection (reflect.ValueOf().MethodByName) instead of direct method calls, since we cannot know at codegen time whether the external type implements ApplyDefaults.

3. Primitive component schema aliases: Component schemas always generate Go type aliases (e.g., type Name = string), even for primitive types. This ensures external packages can reference them by name.

Also adds doc.go with go:generate directives to external_ref test packages and extends the test specs with cross-package reference scenarios (Employee composed of external Name/Address/Occupation fields).