### PR TITLE
Partial Item Schema Support

### DIFF
--- a/experimental/codegen/internal/configuration.go
+++ b/experimental/codegen/internal/configuration.go
@@ -164,6 +164,10 @@ func DefaultContentTypes() []string {
 		`^application/json$`,
 		`^application/.*\+json$`,
 		`^application/x-www-form-urlencoded$`,
+		`^text/event-stream$`,
+		`^application/jsonl$`,
+		`^application/x-ndjson$`,
+		`^application/json-seq$`,
 	}
 }
 

--- a/experimental/codegen/internal/gather.go
+++ b/experimental/codegen/internal/gather.go
@@ -329,10 +329,15 @@ func (g *gatherer) gatherFromResponse(response *v3.Response, basePath SchemaPath
 }
 
 func (g *gatherer) gatherFromMediaType(mt *v3.MediaType, basePath SchemaPath) {
-	if mt == nil || mt.Schema == nil {
+	if mt == nil {
 		return
 	}
-	g.gatherFromSchemaProxy(mt.Schema, basePath.Append("schema"), nil)
+	if mt.Schema != nil {
+		g.gatherFromSchemaProxy(mt.Schema, basePath.Append("schema"), nil)
+	}
+	if mt.ItemSchema != nil {
+		g.gatherFromSchemaProxy(mt.ItemSchema, basePath.Append("itemSchema"), nil)
+	}
 }
 
 func (g *gatherer) gatherFromCallback(callback *v3.Callback, basePath SchemaPath) {

--- a/experimental/codegen/internal/gather_operations.go
+++ b/experimental/codegen/internal/gather_operations.go
@@ -314,6 +314,11 @@ func (g *operationGatherer) gatherRequestBodies(operationID string, bodyRef *v3.
 			schemaDesc = schemaProxyToDescriptor(mediaType.Schema)
 		}
 
+		var itemSchemaDesc *SchemaDescriptor
+		if mediaType.ItemSchema != nil {
+			itemSchemaDesc = schemaProxyToDescriptor(mediaType.ItemSchema)
+		}
+
 		funcSuffix := ""
 		if !isDefault && nameTag != "" {
 			funcSuffix = "With" + nameTag + "Body"
@@ -339,12 +344,14 @@ func (g *operationGatherer) gatherRequestBodies(operationID string, bodyRef *v3.
 			ContentType: contentType,
 			Required:    bodyRequired,
 			Schema:      schemaDesc,
+			ItemSchema:  itemSchemaDesc,
 
 			NameTag:       nameTag,
 			GoTypeName:    goTypeName,
 			FuncSuffix:    funcSuffix,
 			IsDefault:     isDefault,
 			IsFormEncoded: contentType == "application/x-www-form-urlencoded",
+			IsSequential:  IsSequentialMediaType(contentType),
 			GenerateTyped: generateTyped,
 		}
 
@@ -436,13 +443,20 @@ func (g *operationGatherer) gatherResponse(operationID, statusCode string, resp 
 				schemaDesc = schemaProxyToDescriptor(mediaType.Schema)
 			}
 
+			var itemSchemaDesc *SchemaDescriptor
+			if mediaType.ItemSchema != nil {
+				itemSchemaDesc = schemaProxyToDescriptor(mediaType.ItemSchema)
+			}
+
 			nameTag := ComputeBodyNameTag(contentType)
 
 			contents = append(contents, &ResponseContentDescriptor{
-				ContentType: contentType,
-				Schema:      schemaDesc,
-				NameTag:     nameTag,
-				IsJSON:      IsMediaTypeJSON(contentType),
+				ContentType:  contentType,
+				Schema:       schemaDesc,
+				ItemSchema:   itemSchemaDesc,
+				NameTag:      nameTag,
+				IsJSON:       IsMediaTypeJSON(contentType),
+				IsSequential: IsSequentialMediaType(contentType),
 			})
 		}
 	}

--- a/experimental/codegen/internal/itemschema_test.go
+++ b/experimental/codegen/internal/itemschema_test.go
@@ -1,0 +1,305 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func schemaPathStrings(schemas []*SchemaDescriptor) []string {
+	paths := make([]string, len(schemas))
+	for i, s := range schemas {
+		paths[i] = s.Path.String()
+	}
+	return paths
+}
+
+func TestIsSequentialMediaType(t *testing.T) {
+	tests := []struct {
+		contentType string
+		want        bool
+	}{
+		{"text/event-stream", true},
+		{"application/jsonl", true},
+		{"application/x-ndjson", true},
+		{"application/json-seq", true},
+		{"multipart/mixed", true},
+		{"application/json", false},
+		{"text/plain", false},
+		{"application/xml", false},
+		{"multipart/form-data", false},
+		{"application/x-www-form-urlencoded", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.contentType, func(t *testing.T) {
+			got := IsSequentialMediaType(tt.contentType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+const itemSchemaResponseSpec = `openapi: "3.1.0"
+info:
+  title: ItemSchema Test API
+  version: "1.0"
+paths:
+  /events:
+    get:
+      operationId: streamEvents
+      responses:
+        "200":
+          description: OK
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: Raw SSE stream
+              itemSchema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  message:
+                    type: string
+`
+
+const itemSchemaRequestBodySpec = `openapi: "3.1.0"
+info:
+  title: ItemSchema RequestBody Test API
+  version: "1.0"
+paths:
+  /ingest:
+    post:
+      operationId: ingestEvents
+      requestBody:
+        required: true
+        content:
+          application/jsonl:
+            schema:
+              type: string
+              description: Raw JSONL stream
+            itemSchema:
+              type: object
+              properties:
+                event:
+                  type: string
+                timestamp:
+                  type: integer
+      responses:
+        "202":
+          description: Accepted
+`
+
+func TestGatherItemSchema_Response(t *testing.T) {
+	doc, err := libopenapi.NewDocument([]byte(itemSchemaResponseSpec))
+	require.NoError(t, err, "Failed to parse spec")
+
+	contentTypeMatcher := NewContentTypeMatcher(DefaultContentTypes())
+	schemas, err := GatherSchemas(doc, contentTypeMatcher, OutputOptions{})
+	require.NoError(t, err, "Failed to gather schemas")
+
+	// Verify the itemSchema was gathered
+	var foundItemSchema bool
+	for _, s := range schemas {
+		pathStr := s.Path.String()
+		if strings.Contains(pathStr, "itemSchema") {
+			foundItemSchema = true
+			assert.NotNil(t, s.Schema)
+			assert.NotNil(t, s.Schema.Properties)
+			break
+		}
+	}
+	assert.True(t, foundItemSchema, "expected itemSchema to be gathered from response; gathered paths: %v", schemaPathStrings(schemas))
+}
+
+func TestGatherItemSchema_RequestBody(t *testing.T) {
+	doc, err := libopenapi.NewDocument([]byte(itemSchemaRequestBodySpec))
+	require.NoError(t, err, "Failed to parse spec")
+
+	contentTypeMatcher := NewContentTypeMatcher(DefaultContentTypes())
+	schemas, err := GatherSchemas(doc, contentTypeMatcher, OutputOptions{})
+	require.NoError(t, err, "Failed to gather schemas")
+
+	// Verify the itemSchema was gathered
+	var foundItemSchema bool
+	for _, s := range schemas {
+		pathStr := s.Path.String()
+		if strings.Contains(pathStr, "itemSchema") {
+			foundItemSchema = true
+			assert.NotNil(t, s.Schema)
+			assert.NotNil(t, s.Schema.Properties)
+			break
+		}
+	}
+	assert.True(t, foundItemSchema, "expected itemSchema to be gathered from request body; gathered paths: %v", schemaPathStrings(schemas))
+}
+
+func TestGatherOperations_ItemSchema_Response(t *testing.T) {
+	doc, err := libopenapi.NewDocument([]byte(itemSchemaResponseSpec))
+	require.NoError(t, err, "Failed to parse spec")
+
+	ctx := NewCodegenContext()
+	contentTypeMatcher := NewContentTypeMatcher(DefaultContentTypes())
+	ops, err := GatherOperations(doc, ctx, contentTypeMatcher)
+	require.NoError(t, err, "Failed to gather operations")
+	require.Len(t, ops, 1, "Expected 1 operation")
+
+	op := ops[0]
+	assert.Equal(t, "streamEvents", op.OperationID)
+
+	// Find the SSE response content
+	require.NotEmpty(t, op.Responses, "Operation responses should not be empty")
+	resp := op.Responses[0]
+	require.NotEmpty(t, resp.Contents, "Response content should not be empty")
+
+	var sseContent *ResponseContentDescriptor
+	for _, c := range resp.Contents {
+		if c.ContentType == "text/event-stream" {
+			sseContent = c
+			break
+		}
+	}
+	require.NotNil(t, sseContent, "expected text/event-stream content")
+
+	assert.True(t, sseContent.IsSequential)
+	assert.NotNil(t, sseContent.ItemSchema, "expected ItemSchema to be populated")
+	assert.NotNil(t, sseContent.ItemSchema.Schema)
+	assert.NotNil(t, sseContent.ItemSchema.Schema.Properties)
+}
+
+func TestGatherOperations_ItemSchema_RequestBody(t *testing.T) {
+	doc, err := libopenapi.NewDocument([]byte(itemSchemaRequestBodySpec))
+	require.NoError(t, err, "Failed to parse spec")
+
+	ctx := NewCodegenContext()
+	contentTypeMatcher := NewContentTypeMatcher(DefaultContentTypes())
+	ops, err := GatherOperations(doc, ctx, contentTypeMatcher)
+	require.NoError(t, err, "Failed to gather operations")
+	require.Len(t, ops, 1, "Expected 1 operation")
+
+	op := ops[0]
+	assert.Equal(t, "ingestEvents", op.OperationID)
+
+	// Find the JSONL request body
+	require.NotEmpty(t, op.Bodies, "Operation body should not be empty")
+
+	var jsonlBody *RequestBodyDescriptor
+	for _, b := range op.Bodies {
+		if b.ContentType == "application/jsonl" {
+			jsonlBody = b
+			break
+		}
+	}
+	require.NotNil(t, jsonlBody, "expected application/jsonl body")
+
+	assert.True(t, jsonlBody.IsSequential)
+	assert.NotNil(t, jsonlBody.ItemSchema, "expected ItemSchema to be populated")
+	assert.NotNil(t, jsonlBody.ItemSchema.Schema)
+	assert.NotNil(t, jsonlBody.ItemSchema.Schema.Properties)
+}
+
+func TestGatherOperations_NonSequential_HasNoItemSchema(t *testing.T) {
+	const spec = `openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+`
+	doc, err := libopenapi.NewDocument([]byte(spec))
+	require.NoError(t, err, "Failed to parse spec")
+
+	ctx := NewCodegenContext()
+	contentTypeMatcher := NewContentTypeMatcher(DefaultContentTypes())
+	ops, err := GatherOperations(doc, ctx, contentTypeMatcher)
+	require.NoError(t, err, "Failed to gather operations")
+	require.Len(t, ops, 1, "Expected 1 operation")
+
+	resp := ops[0].Responses[0]
+	require.NotEmpty(t, resp.Contents)
+
+	jsonContent := resp.Contents[0]
+	assert.False(t, jsonContent.IsSequential, "Contents should not be sequential")
+	assert.Nil(t, jsonContent.ItemSchema, "Item Schema should be empty")
+}
+
+func TestGenerate_ItemSchema(t *testing.T) {
+	const spec = `openapi: "3.1.0"
+info:
+  title: Streaming API
+  version: "1.0"
+paths:
+  /events:
+    get:
+      operationId: streamEvents
+      responses:
+        "200":
+          description: OK
+          content:
+            text/event-stream:
+              schema:
+                type: string
+              itemSchema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  message:
+                    type: string
+  /ingest:
+    post:
+      operationId: ingestData
+      requestBody:
+        required: true
+        content:
+          application/x-ndjson:
+            schema:
+              type: string
+            itemSchema:
+              $ref: '#/components/schemas/Event'
+      responses:
+        "202":
+          description: Accepted
+components:
+  schemas:
+    Event:
+      type: object
+      properties:
+        type:
+          type: string
+        data:
+          type: string
+`
+
+	doc, err := libopenapi.NewDocument([]byte(spec))
+	require.NoError(t, err, "Failed to parse spec")
+
+	cfg := Configuration{
+		PackageName: "testpkg",
+	}
+
+	code, err := Generate(doc, []byte(spec), cfg)
+	require.NoError(t, err)
+	assert.NotEmpty(t, code)
+
+	// Verify the itemSchema types are generated
+	assert.Contains(t, code, "Event")
+}

--- a/experimental/codegen/internal/operation.go
+++ b/experimental/codegen/internal/operation.go
@@ -184,7 +184,7 @@ type RequestBodyDescriptor struct {
 	FuncSuffix    string // "", "WithJSONBody", "WithFormBody" (empty for default)
 	IsDefault     bool   // Is this the default body type?
 	IsFormEncoded bool   // Is this application/x-www-form-urlencoded?
-	IsSequential  bool   // True for streaming content types (SSE, NDJSON, etc.)
+	IsSequential  bool   // Is this a streaming content types (SSE, NDJSON, etc.)?
 	GenerateTyped bool   // Generate typed methods for this body (based on content-types config)
 
 	// Encoding options for form data

--- a/experimental/codegen/internal/operation.go
+++ b/experimental/codegen/internal/operation.go
@@ -176,14 +176,16 @@ type RequestBodyDescriptor struct {
 	ContentType string // "application/json", "multipart/form-data", etc.
 	Required    bool
 	Schema      *SchemaDescriptor
+	ItemSchema  *SchemaDescriptor // Per-item schema for sequential media types (OpenAPI 3.2)
 
 	// Precomputed for templates
-	NameTag    string // "JSON", "Formdata", "Multipart", "Text", etc.
-	GoTypeName string // "{OperationID}JSONBody", etc.
-	FuncSuffix string // "", "WithJSONBody", "WithFormBody" (empty for default)
-	IsDefault     bool // Is this the default body type?
-	IsFormEncoded bool // Is this application/x-www-form-urlencoded?
-	GenerateTyped bool // Generate typed methods for this body (based on content-types config)
+	NameTag       string // "JSON", "Formdata", "Multipart", "Text", etc.
+	GoTypeName    string // "{OperationID}JSONBody", etc.
+	FuncSuffix    string // "", "WithJSONBody", "WithFormBody" (empty for default)
+	IsDefault     bool   // Is this the default body type?
+	IsFormEncoded bool   // Is this application/x-www-form-urlencoded?
+	IsSequential  bool   // True for streaming content types (SSE, NDJSON, etc.)
+	GenerateTyped bool   // Generate typed methods for this body (based on content-types config)
 
 	// Encoding options for form data
 	Encoding map[string]RequestBodyEncoding
@@ -224,10 +226,12 @@ func (r *ResponseDescriptor) HasFixedStatusCode() bool {
 
 // ResponseContentDescriptor describes response content for a content type.
 type ResponseContentDescriptor struct {
-	ContentType string
-	Schema      *SchemaDescriptor
-	NameTag     string // "JSON", "XML", etc.
-	IsJSON      bool
+	ContentType  string
+	Schema       *SchemaDescriptor
+	ItemSchema   *SchemaDescriptor // Per-item schema for sequential media types (OpenAPI 3.2)
+	NameTag      string            // "JSON", "XML", etc.
+	IsJSON       bool
+	IsSequential bool // True for streaming content types (SSE, NDJSON, etc.)
 }
 
 // ResponseHeaderDescriptor describes a response header.
@@ -293,6 +297,20 @@ func IsMediaTypeJSON(contentType string) bool {
 		return true
 	}
 	if strings.Contains(contentType, "json") {
+		return true
+	}
+	return false
+}
+
+// IsSequentialMediaType returns true if the content type represents a sequential/streaming
+// media type that delivers items one at a time (SSE, NDJSON, JSONL, JSON-seq, multipart/mixed).
+func IsSequentialMediaType(contentType string) bool {
+	switch contentType {
+	case "text/event-stream",
+		"application/jsonl",
+		"application/x-ndjson",
+		"application/json-seq",
+		"multipart/mixed":
 		return true
 	}
 	return false


### PR DESCRIPTION
AI Usage Disclosure: Claude Code Opus 4.6 was used in developing this PR

Apologies for raising this PR without opening an issue and discussing first

OpenAPI 3.2 introduced support for sequential and streaming data, including:

- [Server-Sent Events](https://spec.openapis.org/oas/v3.2.0.html#server-sent-event-streams): text/event-stream
- [Sequential JSON](https://spec.openapis.org/oas/v3.2.0.html#sequential-json):
  - JSON Lines: application/jsonl
  - JSON Sequences: application/json-seq
  - NDJSON: application/x-ndjson

This is done using the `itemSchema` [field on the Media Type Object](https://spec.openapis.org/oas/v3.2.0.html#fixed-fields-11)

## Existing Support

### Server

Nothing has been changed for the server implementation currently and I think all servers should be able to support streaming to clients

- http/std, chi & gorilla: `http.Flusher` should be implemented on the `http.ResponseWriter` so they can send then flush
- echo: can access the flusher from the echo context with `http.NewResponseController(ctx.Response()).Flush()` https://echo.labstack.com/docs/cookbook/sse
- gin: this is handled by [`*Context.Stream()`](https://pkg.go.dev/github.com/gin-gonic/gin#Context.Stream) with [helpers available for SSE](https://pkg.go.dev/github.com/gin-gonic/gin#Context.SSEvent)
- iris: can access the flusher with `ctx.ResponseWriter().Flusher()` https://iris-go.gitbook.io/iris/responses/sse#server-side-code-example
- fiber: uses `fasthttp.StreamWriter` as shown in https://github.com/gofiber/recipes/blob/master/sse/main.go

### Client

Nothing has been changed on the client generation. The base client should be able to handle the events from *http.Response without further changes.

## Changes

This PR includes the following changes, providing additional support for ItemSchema:

 `codegen/internal/operation.go`:
  - Added `ItemSchema *SchemaDescriptor` and `IsSequential bool` to `RequestBodyDescriptor` and `ResponseContentDescriptor`
  - Added `IsSequentialMediaType(contentType string) bool` helper — recognises aforementioned sequential/streaming content types

  `codegen/internal/gather.go`:
  - Updated `gatherFromMediaType()` to also gather `mt.ItemSchema` when present

  `codegen/internal/configuration.go`:
  - Extended `DefaultContentTypes()` to include aforementioned sequential/streaming content types

  `codegen/internal/gather_operations.go`:
  - `gatherResponse()`: extracts `mediaType.ItemSchema` via `schemaProxyToDescriptor()`, sets `IsSequential` on `ResponseContentDescriptor`
  - `gatherRequestBodies()`: same for `RequestBodyDescriptor`
  
In terms of changes to generated code, types for items described by `itemSchema` will now be generated. The other changes are there to allow extending client/server generation where needed

## Outstanding

### SimpleClient

The SimpleClient will currently ignore these operations and so corresponding methods will not be generated:

https://github.com/oapi-codegen/oapi-codegen-exp/blob/71d49076d58cb096f534606a2f2f796cad30c046/experimental/codegen/internal/templates/files/client/simple.go.tmpl#L39-L40

https://github.com/oapi-codegen/oapi-codegen-exp/blob/71d49076d58cb096f534606a2f2f796cad30c046/experimental/codegen/internal/clientgen.go#L136-L137

Would you want support for this in the simple client?

### Strict Server

Are there plans to implement strict server similar to the previous version? `IsSequential` and `ItemSchema` are available on the descriptors to help handle this

### Client -> Server

Reading the spec, I think it technically supports `itemSchema` in a `Media Type Object` that's in a `Request Body Object` rather than a `Response Object` but I don't think that's a typical use case and isn't a use case specifically referenced in the documentation. If you don't want to support it, we can revert the changes on `RequestBodyDescriptor`
