### PR TITLE
experimental: merge allOf member extensions before type generation

### DIFF
--- a/experimental/codegen/internal/extension.go
+++ b/experimental/codegen/internal/extension.go
@@ -277,6 +277,44 @@ func buildLegacyTypeOverride(typeName string, importVal any) *TypeOverride {
 	return override
 }
 
+// mergeExtensions copies non-zero/non-nil fields from src into dst.
+// Later values win (src overrides dst where set).
+func mergeExtensions(dst, src *Extensions) {
+	if src == nil || dst == nil {
+		return
+	}
+	if src.TypeOverride != nil {
+		dst.TypeOverride = src.TypeOverride
+	}
+	if src.NameOverride != "" {
+		dst.NameOverride = src.NameOverride
+	}
+	if src.TypeNameOverride != "" {
+		dst.TypeNameOverride = src.TypeNameOverride
+	}
+	if src.SkipOptionalPointer != nil {
+		dst.SkipOptionalPointer = src.SkipOptionalPointer
+	}
+	if src.JSONIgnore != nil {
+		dst.JSONIgnore = src.JSONIgnore
+	}
+	if src.OmitEmpty != nil {
+		dst.OmitEmpty = src.OmitEmpty
+	}
+	if src.OmitZero != nil {
+		dst.OmitZero = src.OmitZero
+	}
+	if len(src.EnumVarNames) > 0 {
+		dst.EnumVarNames = src.EnumVarNames
+	}
+	if src.DeprecatedReason != "" {
+		dst.DeprecatedReason = src.DeprecatedReason
+	}
+	if src.Order != nil {
+		dst.Order = src.Order
+	}
+}
+
 // Type conversion helpers that include the extension name in error messages
 
 func asString(val any, extName string) (string, error) {

--- a/experimental/codegen/internal/test/previous_version/issues/issue_1957/output/types.gen.go
+++ b/experimental/codegen/internal/test/previous_version/issues/issue_1957/output/types.gen.go
@@ -31,7 +31,7 @@ type ID = googleuuid.UUID
 
 // #/components/schemas/TypeWithAllOf
 type TypeWithAllOf struct {
-	ID *TypeWithAllOfID `json:"id,omitempty" form:"id,omitempty"`
+	ID googleuuid.UUID `json:"id,omitempty" form:"id,omitempty"`
 }
 
 // ApplyDefaults sets default values for fields that are nil.
@@ -39,12 +39,7 @@ func (s *TypeWithAllOf) ApplyDefaults() {
 }
 
 // #/components/schemas/TypeWithAllOf/properties/id
-type TypeWithAllOfID struct {
-}
-
-// ApplyDefaults sets default values for fields that are nil.
-func (s *TypeWithAllOfID) ApplyDefaults() {
-}
+type TypeWithAllOfID = googleuuid.UUID
 
 type GetRootParameter = googleuuid.UUID
 


### PR DESCRIPTION
Refactor allOf type generation to merge extensions from all allOf members into a composite before deciding what code to generate, mirroring V2's MergeSchemas approach. This was surfaced by the issue 1957 test, which uses the standard OpenAPI 3.0 pattern of combining a $ref with extension-only allOf members:

    id:
      allOf:
        - $ref: '#/components/schemas/ID'        # has x-go-type
        - x-go-type-skip-optional-pointer: true   # extension-only

Previously, V3 preserved the allOf structure as-is, so generateAllOfType() only collected struct fields from each member. When a $ref target was a type-override alias (no struct properties), there were no fields to collect, producing an empty struct. Extensions on allOf members were also never propagated to the parent field.

The fix adds three pieces:

- mergeExtensions(dst, src) in extension.go: field-by-field merge helper for the Extensions struct (later values win).

- mergeAllOfExtensions() + hasAnyFields() in codegen.go: iterates allOf member descriptors, resolves $ref targets from the schema index, and merges all extensions. generateAllOfType() now calls this at the top and, when the composite has no struct fields but carries a TypeOverride, emits a type alias instead of an empty struct.

- GenerateStructFields() in typegen.go: when a property is itself an allOf, merges extensions from its allOf members into the property's extensions, so x-go-type-skip-optional-pointer propagates to the field declaration in the parent struct.