### PR TITLE
Fix runtime params/types/helpers package name collisions (#18)

### DIFF
--- a/experimental/codegen/internal/codegen.go
+++ b/experimental/codegen/internal/codegen.go
@@ -24,9 +24,9 @@ func Generate(doc libopenapi.Document, specData []byte, cfg Configuration) (stri
 	var runtimePrefixes RuntimePrefixes
 	if cfg.Generation.RuntimePackage != nil {
 		runtimePrefixes = RuntimePrefixes{
-			Params:  "params.",
-			Types:   "types.",
-			Helpers: "helpers.",
+			Params:  "oapiCodegenParamsPkg.",
+			Types:   "oapiCodegenTypesPkg.",
+			Helpers: "oapiCodegenHelpersPkg.",
 		}
 		ctx.SetRuntimePrefixes(runtimePrefixes.Params, runtimePrefixes.Types, runtimePrefixes.Helpers)
 	}
@@ -343,12 +343,12 @@ func Generate(doc libopenapi.Document, specData []byte, cfg Configuration) (stri
 	if cfg.Generation.RuntimePackage != nil {
 		// Runtime package is configured — don't embed helpers, import them.
 		// Add imports for whichever sub-packages are actually needed.
-		ctx.AddImport(cfg.Generation.RuntimePackage.TypesImport())
+		ctx.AddImportAlias(cfg.Generation.RuntimePackage.TypesImport(), "oapiCodegenTypesPkg")
 		if ctx.HasAnyParams() {
-			ctx.AddImport(cfg.Generation.RuntimePackage.ParamsImport())
+			ctx.AddImportAlias(cfg.Generation.RuntimePackage.ParamsImport(), "oapiCodegenParamsPkg")
 		}
 		if len(ctx.RequiredHelpers()) > 0 {
-			ctx.AddImport(cfg.Generation.RuntimePackage.HelpersImport())
+			ctx.AddImportAlias(cfg.Generation.RuntimePackage.HelpersImport(), "oapiCodegenHelpersPkg")
 		}
 	} else {
 		// Resolve param template dependencies first — this may register

--- a/experimental/examples/webhook/doorbadge.gen.go
+++ b/experimental/examples/webhook/doorbadge.gen.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
-	"github.com/oapi-codegen/oapi-codegen-exp/experimental/runtime/params"
-	"github.com/oapi-codegen/oapi-codegen-exp/experimental/runtime/types"
+	oapiCodegenParamsPkg "github.com/oapi-codegen/oapi-codegen-exp/experimental/runtime/params"
+	oapiCodegenTypesPkg "github.com/oapi-codegen/oapi-codegen-exp/experimental/runtime/types"
 )
 
 // #/components/schemas/WebhookRegistration
@@ -33,7 +33,7 @@ func (s *WebhookRegistration) ApplyDefaults() {
 // #/components/schemas/WebhookRegistrationResponse
 type WebhookRegistrationResponse struct {
 	// Unique identifier for this webhook registration
-	ID types.UUID `json:"id" form:"id"`
+	ID oapiCodegenTypesPkg.UUID `json:"id" form:"id"`
 }
 
 // ApplyDefaults sets default values for fields that are nil.
@@ -156,7 +156,7 @@ func (siw *ServerInterfaceWrapper) DeregisterWebhook(w http.ResponseWriter, r *h
 	// ------------- Path parameter "id" -------------
 	var id uuid.UUID
 
-	err = params.BindSimpleParam("id", params.ParamLocationPath, r.PathValue("id"), &id)
+	err = oapiCodegenParamsPkg.BindSimpleParam("id", oapiCodegenParamsPkg.ParamLocationPath, r.PathValue("id"), &id)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
 		return
@@ -180,7 +180,7 @@ func (siw *ServerInterfaceWrapper) RegisterWebhook(w http.ResponseWriter, r *htt
 	// ------------- Path parameter "kind" -------------
 	var kind string
 
-	err = params.BindSimpleParam("kind", params.ParamLocationPath, r.PathValue("kind"), &kind)
+	err = oapiCodegenParamsPkg.BindSimpleParam("kind", oapiCodegenParamsPkg.ParamLocationPath, r.PathValue("kind"), &kind)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
 		return


### PR DESCRIPTION
Use explicit import aliases (oapiCodegenParamsPkg, oapiCodegenTypesPkg, oapiCodegenHelpersPkg) for runtime sub-packages so generated code no longer collides with local variables named `params` or `types`.

Fixes #18