### PR TITLE
Fix go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you are using `v2.3.0` or above, please install like so, using the new module
 
 ```sh
 # for the binary install
-go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+go install github.com/oapi-codegen/oapi-codegen-exp/v2/cmd/oapi-codegen@latest
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then, each invocation of `oapi-codegen` would be used like so:
 Alternatively, you can install it as a binary with:
 
 ```sh
-$ go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+$ go install github.com/oapi-codegen/oapi-codegen-exp/v2/cmd/oapi-codegen@latest
 $ oapi-codegen -version
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/oapi-codegen/oapi-codegen/v2
+module github.com/oapi-codegen/oapi-codegen-exp/v2
 
 go 1.22.5
 


### PR DESCRIPTION
Hi.

I'm using go1.24.9 and while running the 
```bash
# go install github.com/oapi-codegen/oapi-codegen-exp/v2/cmd/oapi-codegen@latest
```
I'm getting the next error:
```
go: downloading github.com/oapi-codegen/oapi-codegen-exp/v2 v2.0.0-20260221230923-f30a72437a99
go: github.com/oapi-codegen/oapi-codegen-exp/v2/cmd/oapi-codegen@latest: version constraints conflict:
	github.com/oapi-codegen/oapi-codegen-exp/v2@v2.0.0-20260221230923-f30a72437a99: parsing go.mod:
	module declares its path as: github.com/oapi-codegen/oapi-codegen/v2
	        but was required as: github.com/oapi-codegen/oapi-codegen-exp/v2
```
Tried to fix it in this PR. Or am I installing it in a wrong way?